### PR TITLE
add ipfs support for json-ld context

### DIFF
--- a/lib/src/json_ld_processor_base.dart
+++ b/lib/src/json_ld_processor_base.dart
@@ -390,8 +390,10 @@ class JsonLdOptions {
 /// Returns a RemoteDocument.
 Future<RemoteDocument> loadDocument(
     Uri url, LoadDocumentOptions? options) async {
+  // replace ipfs:// scheme with default IPFS gateway
+  var http_url = url.isScheme('ipfs') ? Uri.parse('https://ipfs.io/ipfs/' + url.host) : url;
   var response =
-      await get(url, headers: {'content-Type': 'application/ld+json'});
+      await get(http_url, headers: {'content-Type': 'application/ld+json'});
 
   if (response.statusCode == 301 ||
       response.statusCode == 302 ||


### PR DESCRIPTION
Allow resolution of the ipfs:// context scheme by directing it to the ipfs.io default gateway in the default documentLoader

Similar to @digitalbazaar json-ld processor https://github.com/digitalbazaar/jsonld.js/pull/513

Recently added to curl as well https://github.com/curl/curl/pull/8805